### PR TITLE
Fix error when Skpr config is not present

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	config, err := skprconfig.Load()
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, skprconfig.ErrNotFound) {
 		panic(err)
 	}
 


### PR DESCRIPTION
**Overview**

Resolves an issue when running locally and Skpr config file is not provided.

```
$ dist/skprmail_linux_amd64_v1/skprmail 
panic: configuration not found

goroutine 1 [running]:
main.main()
	/home/nick/code/src/github.com/skpr/mail/main.go:61 +0x84c
```

This is because the Skpr config package update the error it was returning.

**Solution**

Check the correct error.