### PR TITLE
Add skpr config support to the default provider

### DIFF
--- a/internal/provider/default/default.go
+++ b/internal/provider/default/default.go
@@ -2,14 +2,12 @@ package local
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/mail"
 	"net/smtp"
 	"os"
 
-	skprconfig "github.com/skpr/go-config"
 	"github.com/skpr/mail/internal/mailutils"
 )
 
@@ -18,24 +16,14 @@ const (
 	EnvAddr = "SKPRMAIL_ADDR"
 	// EnvFrom used to configure the FROM address appled to mail.
 	EnvFrom = "SKPRMAIL_FROM"
-	// EnvPort used to configure the port for the destination address.
-	EnvPort = "SKPRMAIL_PORT"
 	// FallbackAddr where mail will be forwarded to.
-	FallbackAddr = "mail"
+	FallbackAddr = "mail:1025"
 	// FallbackFrom address which will be applied to email.
 	FallbackFrom = "skprmail"
-	// FallbackPort address which will be applied to email.
-	FallbackPort = "1025"
-	// ConfigAddr used to override and set the address where mail is sent using a Skpr config.
-	ConfigAddr = "smtp.hostname"
-	// ConfigFrom used to override and set the FROM address where mail is sent using a Skpr config.
-	ConfigFrom = "smtp.from.address"
-	// ConfigPort used to override and set the address port where mail is sent using a Skpr config.
-	ConfigPort = "smtp.port"
 )
 
 // Send the email to Mailhog.
-func Send(ctx context.Context, to []string, msg *mail.Message) error {
+func Send(ctx context.Context, addr string, to []string, msg *mail.Message) error {
 	// The GO SMTP package is difficult to cancel using context.
 	// This provider should only ever be used for local development tasks.
 	go func() {
@@ -43,11 +31,6 @@ func Send(ctx context.Context, to []string, msg *mail.Message) error {
 		fmt.Println("Context cancelled")
 		os.Exit(1)
 	}()
-
-	config, err := skprconfig.Load()
-	if err != nil && !errors.Is(err, skprconfig.ErrNotFound) {
-		panic(err)
-	}
 
 	data, err := mailutils.MessageToBytes(msg)
 	if err != nil {
@@ -58,29 +41,24 @@ func Send(ctx context.Context, to []string, msg *mail.Message) error {
 		to = append(to, val...)
 	}
 
-	addr := os.Getenv(EnvAddr)
 	if addr == "" {
-		addr = config.GetWithFallback(ConfigAddr, FallbackAddr)
-	}
-
-	port := os.Getenv(EnvPort)
-	if port == "" {
-		port = config.GetWithFallback(ConfigPort, FallbackPort)
+		addr = os.Getenv(EnvAddr)
+		if addr == "" {
+			addr = FallbackAddr
+		}
 	}
 
 	from := os.Getenv(EnvFrom)
 	if from == "" {
-		from = config.GetWithFallback(ConfigFrom, FallbackFrom)
+		addr = FallbackFrom
 	}
 
-	destination := fmt.Sprintf("%s:%s", addr, port)
-
-	err = smtp.SendMail(destination, nil, from, to, data)
+	err = smtp.SendMail(addr, nil, from, to, data)
 	if err != nil {
-		return fmt.Errorf("failed to send message via mailhog smtp %w", err)
+		return fmt.Errorf("failed to send message via mail smtp %w", err)
 	}
 
-	log.Println("successfully sent message via mailhog smtp")
+	log.Println("successfully sent message via mail smtp")
 
 	return nil
 }

--- a/internal/provider/default/default.go
+++ b/internal/provider/default/default.go
@@ -2,12 +2,14 @@ package local
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/mail"
 	"net/smtp"
 	"os"
 
+	skprconfig "github.com/skpr/go-config"
 	"github.com/skpr/mail/internal/mailutils"
 )
 
@@ -16,10 +18,20 @@ const (
 	EnvAddr = "SKPRMAIL_ADDR"
 	// EnvFrom used to configure the FROM address appled to mail.
 	EnvFrom = "SKPRMAIL_FROM"
+	// EnvPort used to configure the port for the destination address.
+	EnvPort = "SKPRMAIL_PORT"
 	// FallbackAddr where mail will be forwarded to.
-	FallbackAddr = "mail:1025"
+	FallbackAddr = "mail"
 	// FallbackFrom address which will be applied to email.
 	FallbackFrom = "skprmail"
+	// FallbackPort address which will be applied to email.
+	FallbackPort = "1025"
+	// ConfigAddr used to override and set the address where mail is sent using a Skpr config.
+	ConfigAddr = "smtp.hostname"
+	// ConfigFrom used to override and set the FROM address where mail is sent using a Skpr config.
+	ConfigFrom = "smtp.from.address"
+	// ConfigPort used to override and set the address port where mail is sent using a Skpr config.
+	ConfigPort = "smtp.port"
 )
 
 // Send the email to Mailhog.
@@ -32,6 +44,11 @@ func Send(ctx context.Context, to []string, msg *mail.Message) error {
 		os.Exit(1)
 	}()
 
+	config, err := skprconfig.Load()
+	if err != nil && !errors.Is(err, skprconfig.ErrNotFound) {
+		panic(err)
+	}
+
 	data, err := mailutils.MessageToBytes(msg)
 	if err != nil {
 		return err
@@ -43,15 +60,22 @@ func Send(ctx context.Context, to []string, msg *mail.Message) error {
 
 	addr := os.Getenv(EnvAddr)
 	if addr == "" {
-		addr = FallbackAddr
+		addr = config.GetWithFallback(ConfigAddr, FallbackAddr)
+	}
+
+	port := os.Getenv(EnvPort)
+	if port == "" {
+		port = config.GetWithFallback(ConfigPort, FallbackPort)
 	}
 
 	from := os.Getenv(EnvFrom)
 	if from == "" {
-		addr = FallbackFrom
+		from = config.GetWithFallback(ConfigFrom, FallbackFrom)
 	}
 
-	err = smtp.SendMail(addr, nil, from, to, data)
+	destination := fmt.Sprintf("%s:%s", addr, port)
+
+	err = smtp.SendMail(destination, nil, from, to, data)
 	if err != nil {
 		return fmt.Errorf("failed to send message via mailhog smtp %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	kingpin "github.com/alecthomas/kingpin/v2"
-	skprconfig "github.com/skpr/go-config"
 
+	skprconfig "github.com/skpr/go-config"
 	defaultprovider "github.com/skpr/mail/internal/provider/default"
 	"github.com/skpr/mail/internal/provider/ses"
 )

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/mail"
 	"os"
@@ -10,7 +11,7 @@ import (
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	skprconfig "github.com/skpr/go-config"
-	
+
 	defaultprovider "github.com/skpr/mail/internal/provider/default"
 	"github.com/skpr/mail/internal/provider/ses"
 )
@@ -24,6 +25,10 @@ const (
 	EnvRegion = "SKPRMAIL_SES_REGION"
 	// EnvFrom used to override and set the FROM request for mail using an environment variable.
 	EnvFrom = "SKPRMAIL_FROM"
+	// EnvHostname is the hostname to dispatch the email to.
+	EnvHostname = "SKPRMAIL_HOSTNAME"
+	// EnvPort is the port to be used to dispatch the email.
+	EnvPort = "SKPRMAIL_PORT"
 	// ConfigUsername used to configure authentication using a Skpr config.
 	ConfigUsername = "smtp.username"
 	// ConfigPassword used to configure authentication using a Skpr config.
@@ -32,6 +37,10 @@ const (
 	ConfigRegion = "smtp.region"
 	// ConfigFrom used to override and set the FROM request for mail using a Skpr config.
 	ConfigFrom = "smtp.from.address"
+	// ConfigHostname used to override and set the address where mail is sent using a Skpr config.
+	ConfigHostname = "smtp.hostname"
+	// ConfigPort used to override and set the address port where mail is sent using a Skpr config.
+	ConfigPort = "smtp.port"
 )
 
 var (
@@ -68,6 +77,8 @@ func main() {
 		password = config.GetWithFallback(ConfigPassword, os.Getenv(EnvPassword))
 		region   = config.GetWithFallback(ConfigRegion, os.Getenv(EnvRegion))
 		from     = config.GetWithFallback(ConfigFrom, os.Getenv(EnvFrom))
+		hostname = config.GetWithFallback(ConfigHostname, os.Getenv(EnvHostname))
+		port     = config.GetWithFallback(ConfigPort, os.Getenv(EnvPort))
 	)
 
 	msg, err := mail.ReadMessage(os.Stdin)
@@ -78,18 +89,20 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), *cliTimeout)
 	defer cancel()
 
-	err = send(ctx, region, username, password, from, *cliTo, msg)
+	err = send(ctx, region, username, password, hostname, port, from, *cliTo, msg)
 	if err != nil {
 		log.Fatalf("failed to send message: %s", err)
 	}
 }
 
 // Send email based on parameters.
-func send(ctx context.Context, region, username, password, from string, to []string, msg *mail.Message) error {
+func send(ctx context.Context, region, username, password, hostname, port, from string, to []string, msg *mail.Message) error {
 	// Use AWS if the credentials match what we would expect for IAM.
 	if strings.HasPrefix(username, ses.AccessKeyPrefix) {
 		return ses.Send(ctx, region, username, password, from, to, msg)
 	}
 
-	return defaultprovider.Send(ctx, to, msg)
+	destination := fmt.Sprintf("%s:%s", hostname, port)
+
+	return defaultprovider.Send(ctx, destination, to, msg)
 }


### PR DESCRIPTION
This PR adds support for the following Skpr config items to the default provider.
Seeing as the main entry point will panic without Skpr config this seems reasonable to align it with other known SMTP configuration.

* From address
* Address / Endpoint
* Port

This one appears to be a bug which is resolved by this PR

https://github.com/skpr/mail/blob/main/internal/provider/default/default.go#L51